### PR TITLE
Fixup tarball rewrites to take into account client's requested host

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,11 +150,12 @@ module.exports = {
         //Rewrite tarball URLs to kappa so that everything comes through kappa.
         //This is useful for metrics, logging, white listing, etc.
         plugin.ext('onPostHandler', function (request, next) {
-            var response, rewrite;
+            var response, rewrite, hostInfo;
 
             response = request.response;
             if (!response.isBoom && response.variety === 'plain') {
-                rewrite = util.rewriter(vhost || request.server.info.host, request.server.info.port);
+                hostInfo = util.hostInfo(request);
+                rewrite = util.rewriter(hostInfo.protocol, hostInfo.hostname, hostInfo.port);
                 util.transform(response.source, 'tarball', rewrite);
             }
 

--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -85,7 +85,7 @@ var proto = {
             response.header('x-registry', self.registry);
 
             Object.keys(incoming.headers)
-                .filter(util.filterHeader)
+                .filter(util.isValidHeader)
                 .forEach(function (header) {
                     response.header(header, incoming.headers[header]);
                 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,7 +31,7 @@ INVALID_HEADERS = ['content-length', 'date'];
  * @param header the name of the header to test
  * @returns {boolean} true if the header is valid, or false if not.
  */
-exports.filterHeader = function (header) {
+exports.isValidHeader = function (header) {
     return !~INVALID_HEADERS.indexOf(header);
 };
 
@@ -191,18 +191,38 @@ exports.transform = function transform(obj, prop, fn) {
 
 /**
  * Creates a function that rewrites paths using the provided host and port
- * @param host the host to use when rewriting
+ * @param hostname the host to use when rewriting
  * @param port the port to use when rewriting
  * @returns {Function} a fn which accepts the path to rewrite and returns the rewritten path.
  */
-exports.rewriter = function rewriter(host, port) {
+exports.rewriter = function rewriter(protocol, hostname, port) {
     return function rewrite(path) {
         if (typeof path === 'string') {
             path = url.parse(path);
-            path.host = path.hostname = host;
+            path.protocol = protocol;
+            path.host = path.hostname = hostname;
             path.port = port;
             path = path.format();
         }
         return path;
+    };
+};
+
+/**
+ * Extracts the *client* request host information from the request (i.e. takes into account x-forwarded-proto)
+ * This allows us to know the protocol, host, and port of the originating request.
+ * @param request
+ * @returns {{protocol: *, hostname: *, port: *}}
+ */
+exports.hostInfo = function (request) {
+    var protocol, uri;
+
+    protocol = request.headers['x-forwarded-proto'] || (request.server.info.protocol + ':');
+    uri = url.parse(protocol + '//' + request.info.host);
+
+    return {
+        'protocol': uri.protocol,
+        'hostname': uri.hostname,
+        'port': uri.port
     };
 };


### PR DESCRIPTION
Previously we were rewriting tarball urls with `protocol`, `host`, `port` info that was not necessarily accurate. `protocol` was coming from original tarball url, `host` from `vhost` or internal `server.info` host, and `port` from `server.info`.

This change makes it the same information as the original request from client. i.e:
- `protocol` - the protocol client requested (comes from `x-forwarded-proto` when a LB or ssl terminator is in place).
- `hostname` - comes from `request.info.host`, which reflect the `host` header, stripped of `port`.
- `port` - stripped out from `host` above.
