### PR TITLE
Adding stream payload config for PUT operations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,10 @@ module.exports = {
             path: '/{p*}',
             vhost: vhost,
             config: {
-                handler: write
+                handler: write,
+                payload: {
+                    output: 'stream'
+                }
             }
         });
 


### PR DESCRIPTION
This regression prevented payload from being forwarded to the registries, breaking an command that requires PUTs.
