### PR TITLE
Fix incorrect default.

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
     "paths": [
-        "http://localhost:5984/registry/_design/ghost/_rewrite/",
+        "http://localhost:5984/registry/_design/app/_rewrite/",
         "https://registry.npmjs.org/"
     ],
     "logLevel": "info"


### PR DESCRIPTION
Never should've been `ghost` but instead `app` is correct.
