### PR TITLE
Add server options config example

### DIFF
--- a/example/global/config.json
+++ b/example/global/config.json
@@ -2,7 +2,8 @@
     "servers": [
         {
             "host": "localhost",
-            "port": "env:PORT|d"
+            "port": "env:PORT|d",
+            "options": { "payload": { "maxBytes": 10000000 } }
         },
         {
             "host": "localhost",
@@ -12,7 +13,8 @@
                 "rejectUnauthorized": true,
                 "key": "file:../key.pem",
                 "cert": "file:../cert.pem"
-            }
+            },
+            "options": { "payload": { "maxBytes": 10000000 } }
         }
     ],
     "plugins": {


### PR DESCRIPTION
To help with #50, this PR adds a hint by example of changing Hapi server options in the plugin config. Increasing the max payload size for publishing is likely to be a common need for new users, but making other options settings changes for Hapi should be easier to grok with this hint until more docs are developed.
