### PR TITLE
Fix issue #51 wherein paths were being rewritten incorrectly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
-var hapi = require('hapi'),
+var url = require('url'),
+    hapi = require('hapi'),
     pkg = require('./package'),
     log = require('./lib/log'),
     util = require('./lib/util'),
@@ -160,12 +161,13 @@ module.exports = {
         //Rewrite tarball URLs to kappa so that everything comes through kappa.
         //This is useful for metrics, logging, white listing, etc.
         plugin.ext('onPostHandler', function (request, next) {
-            var response, rewrite, hostInfo;
+            var response, rewrite, host, registry;
 
             response = request.response;
             if (!response.isBoom && response.variety === 'plain') {
-                hostInfo = util.hostInfo(request);
-                rewrite = util.rewriter(hostInfo.protocol, hostInfo.hostname, hostInfo.port);
+                host = util.hostInfo(request);
+                registry = url.parse(response.headers['x-registry'] || '');
+                rewrite = util.rewriter(host, registry);
                 util.transform(response.source, 'tarball', rewrite);
             }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -192,18 +192,19 @@ exports.transform = function transform(obj, prop, fn) {
 /**
  * Creates a function that rewrites paths using the provided host and port
  * @protocol the protocol to use when rewriting
- * @param hostname the host to use when rewriting
- * @param port the port to use when rewriting
+ * @param host the host to use when rewriting
+ * @param registry an url object of the registry to use
  * @returns {Function} a fn which accepts the path to rewrite and returns the rewritten path.
  */
-exports.rewriter = function rewriter(protocol, hostname, port) {
+exports.rewriter = function rewriter(host, registry) {
     return function rewrite(path) {
         if (typeof path === 'string') {
             path = url.parse(path);
+            path.pathname = path.pathname.replace(registry.pathname, '') || '/';
+            path.protocol = host.protocol;
+            path.hostname = host.hostname;
+            path.port = host.port;
             path.host = undefined;
-            path.protocol = protocol;
-            path.hostname = hostname;
-            path.port = port;
             path = path.format();
         }
         return path;


### PR DESCRIPTION
When registry urls contained path segments the rewriter didn't correctly strip the segments prior to appending the true file path. This corrects that behavior.
