### PR TITLE
Preserve query params when proxying

### DIFF
--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -48,7 +48,7 @@ var proto = {
     proxy: function (req, reply) {
         var resource, options;
 
-        resource = url.resolve(this.registry, req.path.substring(1));
+        resource = url.resolve(this.registry, req.url.path.substring(1));
         options = url.parse(resource);
         options.method = req.method.toLowerCase();
         options.rejectUnauthorized = false;

--- a/test/fixtures/get.json
+++ b/test/fixtures/get.json
@@ -78,6 +78,15 @@
                     },
                     "body": null
                 }
+            },
+            "-/by-field?field=name": {
+                "response": {
+                    "status": 200,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {"pkg": {"name": "pkg"}}
+                }
             }
         }
     },

--- a/test/routes.js
+++ b/test/routes.js
@@ -220,6 +220,21 @@ test('get', function (t) {
         });
     });
 
+    t.test('query params', function (t) {
+        var req = {
+            headers: {
+                host: 'npm.mydomain.com'
+            },
+            method: 'get',
+            url: '/-/by-field?field=name'
+        };
+
+        server.inject(req, function (res) {
+            t.strictEqual(res.payload, '{"pkg":{"name":"pkg"}}');
+            t.strictEqual(res.statusCode, 200);
+            t.end();
+        });
+    });
 });
 
 


### PR DESCRIPTION
This allows accessing more of npm's API's, e.g. views and lists
