### PR TITLE
Add require shortstop handler and update examples for good 3.x

### DIFF
--- a/example/global/config.json
+++ b/example/global/config.json
@@ -34,9 +34,17 @@
             ]
         },
         "good": {
-            "subscribers": {
-                "console": ["request", "ops", "log", "error"]
-            }
+            "reporters":  [{
+                "reporter": "require:good/lib/reporter",
+                "args": [{
+                    "events": {
+                        "request": "*",
+                        "log": "*",
+                        "error": "*",
+                        "ops": "*"
+                    }
+                }]
+            }]
         }
     }
 }

--- a/example/local/config.json
+++ b/example/local/config.json
@@ -26,9 +26,17 @@
             ]
         },
         "good": {
-            "subscribers": {
-                "console": ["request", "ops", "log", "error"]
-            }
+            "reporters":  [{
+                "reporter": "require:good/lib/reporter",
+                "args": [{
+                    "events": {
+                        "request": "*",
+                        "log": "*",
+                        "error": "*",
+                        "ops": "*"
+                    }
+                }]
+            }]
         }
     }
 }

--- a/kappa.js
+++ b/kappa.js
@@ -28,6 +28,7 @@ resolver = shortstop.create();
 resolver.use('path', handlers.path(basedir));
 resolver.use('file', handlers.file(basedir));
 resolver.use('env',  handlers.env(basedir));
+resolver.use('require', handlers.require(basedir));
 
 manifest = require(path.resolve(basedir, argv.c || argv.config));
 manifest = resolver.resolve(manifest, bomb(function (err, manifest) {


### PR DESCRIPTION
As mentioned [here](https://github.com/hapijs/good/issues/208), `good` configuration now requires a reporter module to operate correctly. This PR adds the `require` shortstop handler to the kappa composer and updates docs to reflect the correct configuration.
