### PR TITLE
Add res conditional and only use host part of registry.

### DIFF
--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -79,7 +79,7 @@ var proto = {
             },
             onResponse: function (error, res, request, reply) {
                 var good, end;
-                
+
                 if (good = request.server.plugins.good) {
                     // The good plugin is available, so report custom `proxy` events.
                     // NOTE: using the `proxy` event type with reporters that cannot
@@ -90,9 +90,9 @@ var proto = {
                         event: 'proxy',
                         duration: end - start,
                         method: request.method,
-                        registry: registry,
+                        registry: Url.parse(registry).host,
                         path: request.path,
-                        statusCode: res.statusCode
+                        statusCode: res ? res.statusCode : -1
                     });
                 }
 


### PR DESCRIPTION
- If an error occurs there will not be a `res` object available. When no res is present default to statusCode of -1.
- Keeping the full path of registry is unnecessary, so just use `host` portion when logging.
