### PR TITLE
Remove unnecessary checks prior to replying.

### DIFF
--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -43,9 +43,7 @@ exports.createHandler = function (registries) {
             },
 
             function complete(err) {
-                if (!iter.complete && typeof reply === 'function') {
-                    reply(err ? Hapi.error.wrap(err) : Hapi.error.notFound('Resource not found'));
-                }
+                reply(err ? Hapi.error.wrap(err) : Hapi.error.notFound('Resource not found'));
             }
 
         );

--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -98,7 +98,7 @@ var proto = {
 
                 self._onResponse.apply(self, arguments);
             },
-            timeout: 5000
+            timeout: 20000
         });
     },
 


### PR DESCRIPTION
Iterator completeness and reply are no longer necessary. Calling `reply` once replied is now a noop in hapi, so no check is required. Also, publishing largo packages will exceed the set 5s timeout, so bumped it to an absurdly high number until we can get that changed to a configuable value.
