### PR TITLE
304 are valid responses.

### DIFF
--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -117,7 +117,7 @@ var proto = {
                 resume = false;
             } else {
                 // Non-primary registries resume on any non-success.
-                resume = res.statusCode !== 200;
+                resume = res.statusCode !== 200 && res.statusCode !== 304;
             }
         }
 


### PR DESCRIPTION
Silly oversight in which 304s were ignored. This rule is probably still not sufficient, but would like to fix this particular bug quickly.
