### PR TITLE
Add request id to proxy logs and always fail on error.

### DIFF
--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -43,6 +43,7 @@ exports.createHandler = function (registries) {
             },
 
             function complete(err) {
+                // If the request has been replied to calls to `reply` are a noop.
                 reply(err ? Hapi.error.wrap(err) : Hapi.error.notFound('Resource not found'));
             }
 

--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -81,7 +81,8 @@ var proto = {
                         method: request.method,
                         registry: Url.parse(registry).host,
                         path: request.path,
-                        statusCode: res ? res.statusCode : -1
+                        statusCode: res ? res.statusCode : -1,
+                        id: request.id
                     });
                 }
 
@@ -92,12 +93,12 @@ var proto = {
     },
 
     _onResponse: function (error, res, request, reply) {
-        var resume, self, response;
+        var self, response;
 
         if (error) {
             // Ensure any necessary socket cleanup is done.
             res && res.socket && res.socket.destroy();
-            this._onError(error);
+            this.onComplete(error);
             return;
         }
 
@@ -111,7 +112,7 @@ var proto = {
 
         self = this;
         response = request.raw.res;
-        response.once('error', this._onError.bind(this));
+        response.once('error', this.onComplete);
         response.once('finish', this.onComplete);
 
         Wreck.read(res, { json: true }, function (err, payload) {
@@ -137,14 +138,6 @@ var proto = {
                 });
         });
 
-    },
-
-    _onError: function (err) {
-        // TODO: Log error even though we ignore it?
-        // If primary registry is down, always fail. This is for the scenario
-        // in which there may be naming collisions and falling back might return
-        // a node module different than the desired/intended one.
-        this.onComplete(this.isFirst ? err : null);
     },
 
 


### PR DESCRIPTION
Fixes #84 and #85. All errors now fail the original request and request id is added to proxy logs such that they can be correlated back to the parent request.
