### PR TITLE
Add a downstream socket timeout reporter

### DIFF
--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -67,7 +67,7 @@ var proto = {
                 callback(null, options.format(), options.headers);
             },
             onResponse: function (error, res, request, reply) {
-                var good, end;
+                var good, end, respondStart, respondEnd;
 
                 if (good = request.server.plugins.good) {
                     // The good plugin is available, so report custom `proxy` events.
@@ -82,7 +82,29 @@ var proto = {
                         registry: Url.parse(registry).host,
                         path: request.path,
                         statusCode: res ? res.statusCode : -1,
-                        id: request.id
+                        id: request.id,
+                        tags: 'proxy',
+                        data: {}
+                    });
+
+                    respondStart = Date.now();
+                    request.raw.res.socket.once('timeout', function () {
+                        // report a timeout event if the consumer socket timeouts
+                        // binding to the socket directly so that the default
+                        // http handler fires
+                        var respondEnd = Date.now();
+                        good.monitor.emit('report', 'timeout', {
+                            timestamp: respondEnd,
+                            event: 'timeout',
+                            duration: respondEnd - respondStart,
+                            method: request.method,
+                            registry: Url.parse(registry).host,
+                            path: request.path,
+                            statusCode: res ? res.statusCode : -1,
+                            id: request.id,
+                            tags:'timeout',
+                            data: {}
+                        });
                     });
                 }
 


### PR DESCRIPTION
Some clients on poor connections were getting socket timeouts.

Adding a reporter that captures those timeouts and lets the default socket
timeout handler clean up.