### PR TITLE
Fix examples for newer "good" versions

### DIFF
--- a/example/global/README.md
+++ b/example/global/README.md
@@ -1,6 +1,6 @@
 #### Global Installation
 ```bash
-$ npm install -g kappa
+$ npm install -g kappa good@^3 good-console@^2
 $ kappa -c ./config.json
 ```
 

--- a/example/global/config.json
+++ b/example/global/config.json
@@ -35,14 +35,12 @@
         },
         "good": {
             "reporters":  [{
-                "reporter": "require:good/lib/reporter",
+                "reporter": "require:good-console",
                 "args": [{
-                    "events": {
-                        "request": "*",
-                        "log": "*",
-                        "error": "*",
-                        "ops": "*"
-                    }
+                    "request": "*",
+                    "log": "*",
+                    "error": "*",
+                    "ops": "*"
                 }]
             }]
         }

--- a/example/local/config.json
+++ b/example/local/config.json
@@ -27,14 +27,12 @@
         },
         "good": {
             "reporters":  [{
-                "reporter": "require:good/lib/reporter",
+                "reporter": "require:good-console",
                 "args": [{
-                    "events": {
-                        "request": "*",
-                        "log": "*",
-                        "error": "*",
-                        "ops": "*"
-                    }
+                    "request": "*",
+                    "log": "*",
+                    "error": "*",
+                    "ops": "*"
                 }]
             }]
         }

--- a/example/local/package.json
+++ b/example/local/package.json
@@ -6,6 +6,7 @@
       "start": "kappa -c config.json"
   },
   "dependencies": {
-    "good": "^2.2.3"
+    "good": "^3",
+    "good-console": "^2"
   }
 }


### PR DESCRIPTION
`good` and its supporting cast has progressed quite a bit.
Updating the examples to pin `good`, etc, and fix the configs.

Will need to revisit when we update to hapi 8 as the newer versions of good have a `peerDependency` on it.

Fixes #89.