### PR TITLE
Fix HEAD support in Kappa

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "minimist": "^1.1.0",
     "shortstop": "^1.0.1",
     "shortstop-handlers": "^1.0.0",
-    "wreck": "^3.0.0"
+    "wreck": "^5.0.0"
   },
   "devDependencies": {
     "istanbul": "^0.3.0",

--- a/test/fixtures/get.json
+++ b/test/fixtures/get.json
@@ -76,7 +76,7 @@
                     "headers": {
                         "content-type": "application/json"
                     },
-                    "body": null
+                    "body": "not valid"
                 }
             },
             "-/by-field?field=name": {

--- a/test/fixtures/head.json
+++ b/test/fixtures/head.json
@@ -5,15 +5,15 @@
             "cdb": {
                 "response": {
                     "status": 200,
-                    "headers": {},
-                    "body": {}
+                    "headers": {"content-type": "application/json"},
+                    "body": null
                 }
             },
             "cdb/0.0.1": {
                 "response": {
                     "status": 200,
-                    "headers": {},
-                    "body": {}
+                    "headers": {"content-type": "application/json"},
+                    "body": null
                 }
             },
             "core-util-is": {
@@ -59,15 +59,15 @@
             "core-util-is": {
                 "response": {
                     "status": 200,
-                    "headers": {},
-                    "body": {}
+                    "headers": {"content-type": "application/json"},
+                    "body": null
                 }
             },
             "core-util-is/1.0.1": {
                 "response": {
                     "status": 200,
-                    "headers": {},
-                    "body": {}
+                    "headers": {"content-type": "application/json"},
+                    "body": null
                 }
             },
             "å": {

--- a/test/routes.js
+++ b/test/routes.js
@@ -343,7 +343,7 @@ test('head', function (t) {
         server.inject(req, function (res) {
             var payload;
 
-            t.equal(typeof res, 'object');
+            t.equal(res.result, null);
             t.ok(/^application\/json/.test(res.headers['content-type']));
             t.strictEqual(res.headers['x-registry'], spec[0].registry);
             t.strictEqual(res.statusCode, 200);
@@ -364,7 +364,7 @@ test('head', function (t) {
         server.inject(req, function (res) {
             var payload;
 
-            t.equal(typeof res, 'object');
+            t.equal(res.result, null);
             t.ok(/^application\/json/.test(res.headers['content-type']));
             t.strictEqual(res.headers['x-registry'], spec[0].registry);
             t.strictEqual(res.statusCode, 200);


### PR DESCRIPTION
We will need to revisit our `head` tests however this should solve the issue.

Fixes #99.