### PR TITLE
Stream binary packages

### DIFF
--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -24,6 +24,7 @@ var Hoek = require('hoek');
 var Wreck = require('wreck');
 var Https = require('https');
 var Util = require('../util');
+var ContentType = require('content-type');
 
 require('tls').SLAB_BUFFER_SIZE = 200 * 1024;
 
@@ -115,7 +116,7 @@ var proto = {
     },
 
     _onResponse: function (error, res, request, reply) {
-        var self, response;
+        var self, response, contentType;
 
         if (error) {
             // Ensure any necessary socket cleanup is done.
@@ -137,29 +138,41 @@ var proto = {
         response.once('error', this.onComplete);
         response.once('finish', this.onComplete);
 
-        Wreck.read(res, { json: true }, function (err, payload) {
-            var response;
+        contentType = res.headers['content-type'];
+        contentType = contentType && ContentType.parse(contentType).type; // lol
 
-            if (err) {
-                // Actual parsing error, so fail immediately.
-                // The server returned an invalid response
-                // so the client should be notified.
-                err = Hapi.error.wrap(err);
-                err.output.headers['x-registry'] = self.registry;
-                reply(err);
-                return;
-            }
+        if (contentType === 'application/octet-stream') {
+            self._respond(res, res, reply);
+        } else {
+            Wreck.read(res, { json: true }, function (err, payload) {
+                var response;
 
-            response = reply(payload).code(res.statusCode);
-            response.header('x-registry', self.registry);
+                if (err) {
+                    // Actual parsing error, so fail immediately.
+                    // The server returned an invalid response
+                    // so the client should be notified.
+                    err = Hapi.error.wrap(err);
+                    err.output.headers['x-registry'] = self.registry;
+                    reply(err);
+                    return;
+                }
 
-            Object.keys(res.headers)
-                .filter(Util.isValidHeader)
-                .forEach(function (key) {
-                    response.header(key, res.headers[key]);
-                });
-        });
+                self._respond(payload, res, reply);
+            });
+        }
+    },
 
+    _respond: function (obj, res, reply) {
+        var response = reply(obj).code(res.statusCode);
+        response.header('x-registry', this.registry);
+
+        Object.keys(res.headers)
+            .filter(Util.isValidHeader)
+            .forEach(function (key) {
+                response.header(key, res.headers[key]);
+            });
+
+        return response;
     },
 
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "engineStrict": true,
   "dependencies": {
     "async": "^0.9.0",
+    "content-type": "^1.0.1",
     "hapi": "^7.0.0",
     "hoek": "^2.4.1",
     "minimist": "^1.1.0",

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var url = require('url');
+var test = require('tape');
+var Hapi = require('hapi');
+var nock = require('nock');
+var settings = require('../config/defaults');
+var kappa = require('../');
+var Stream = require('stream');
+var Wreck = require('wreck');
+
+test('proxy octet-streams', function (t) {
+    var uri, server, stream;
+
+    // Configure nock for this single request.
+    uri = url.parse(settings.paths[0]);
+
+    nock(uri.protocol + '//' + uri.host).get(uri.pathname + 'cdb').reply(200, function () {
+      stream = new Stream.PassThrough();
+      stream.push('pre'); // doing this to flush the headers early
+      return stream;
+    }, {'content-type': 'application/octet-stream'});
+
+    t.plan(6);
+
+    server = new Hapi.Server(0);
+    server.pack.register({
+        plugin: kappa,
+        options: settings
+    }, function (err) {
+        t.error(err);
+
+        server.start(function () {
+            Wreck.request('get', 'http://localhost:' + server.info.port + '/cdb', null, function (err, res) {
+                t.error(err);
+                t.strictEqual(res.statusCode, 200);
+                Wreck.toReadableStream('post').pipe(stream);
+                Wreck.read(res, null, function (err, payload) {
+                  t.error(err);
+                  t.ok(payload);
+                  t.equal(payload.toString(), 'prepost');
+                  server.stop();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, we were buffering packages.

This should 1) decrease our RSS by not having to allocate massive buffers and 2) decrease response time by streaming responses immediately.