### PR TITLE
Better socket timeout reporting.

### DIFF
--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -31,7 +31,7 @@ exports.createHandler = function (registries) {
 
         if (good = req.server.plugins.good) {
             start = Date.now();
-            req.raw.res.on('timeout', function () {
+            req.raw.res.once('timeout', function () {
                 var end = Date.now();
                 good.monitor.emit('report', 'timeout', {
                     timestamp: end,

--- a/lib/delegate/index.js
+++ b/lib/delegate/index.js
@@ -26,7 +26,27 @@ var Iterator = require('./iterator');
 exports.createHandler = function (registries) {
 
     return function (req, reply) {
+        var good, start;
         var iter = new Iterator(registries, factory);
+
+        if (good = req.server.plugins.good) {
+            start = Date.now();
+            req.raw.res.on('timeout', function () {
+                var end = Date.now();
+                good.monitor.emit('report', 'timeout', {
+                    timestamp: end,
+                    event: 'timeout',
+                    duration: end - start,
+                    method: req.method,
+                    path: req.path,
+                    id: req.id,
+                    tags:'timeout',
+                    data: {}
+                });
+
+                req.raw.res.socket.destroy();
+            });
+        }
 
         async.doWhilst(
 

--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -68,7 +68,7 @@ var proto = {
                 callback(null, options.format(), options.headers);
             },
             onResponse: function (error, res, request, reply) {
-                var good, end, respondStart, respondEnd;
+                var good, end;
 
                 if (good = request.server.plugins.good) {
                     // The good plugin is available, so report custom `proxy` events.
@@ -86,26 +86,6 @@ var proto = {
                         id: request.id,
                         tags: 'proxy',
                         data: {}
-                    });
-
-                    respondStart = Date.now();
-                    request.raw.res.socket.once('timeout', function () {
-                        // report a timeout event if the consumer socket timeouts
-                        // binding to the socket directly so that the default
-                        // http handler fires
-                        var respondEnd = Date.now();
-                        good.monitor.emit('report', 'timeout', {
-                            timestamp: respondEnd,
-                            event: 'timeout',
-                            duration: respondEnd - respondStart,
-                            method: request.method,
-                            registry: Url.parse(registry).host,
-                            path: request.path,
-                            statusCode: res ? res.statusCode : -1,
-                            id: request.id,
-                            tags:'timeout',
-                            data: {}
-                        });
                     });
                 }
 


### PR DESCRIPTION
Dumb oversight on my part. Binding on a socket (which gets reused a bunch) once per proxy. Now binding once per request, on the response, and destroying the socket manually.

Fine on `res` because Hapi (-> Subtext -> Wreck) takes care of `req` timeouts for us.