### PR TITLE
remove x-forwarded-proto header

### DIFF
--- a/lib/delegate/proxy.js
+++ b/lib/delegate/proxy.js
@@ -56,6 +56,12 @@ var proto = {
                 options.headers = Hoek.clone(request.raw.req.headers);
                 delete options.headers.host;
 
+                // remove the x-forwarded-proto header because the couchapp doesn't
+                // handle proto chains (i.e., "https, http").
+                if (options.headers['x-forwarded-proto']) {
+                    delete options.headers['x-forwarded-proto'];
+                }
+
                 // HACK: Only ever send auth to first server.
                 // This is a unique situation where, for writes we ONLY go to a single
                 // repo so this is a noop, but for GETs we fallback to others. If we


### PR DESCRIPTION
This was fun.

Turns out the couchapp [already handles host rewrites](https://github.com/npm/npm-registry-couchapp/blob/0134b24144ba1c445df9518523b6b448781da651/registry/shows.js#L124-L125) which is cool (they implemented it two months before we did).

Unfortunately, it assumes one link in the proto and host chain.

If your LB passes x-forwarded-* headers correctly, it joins the new value against an existing header. So assuming you have one LB terminating SSL followed by a second LB (to balance couch, for example), your `x-forwarded-proto` value will likely be `https, http`. The couchapp blindly uses the string which means your rewrites resolve to `https, http://1.2.3.4/file/-/file-0.0.0.tgz`.

This is a hack to get around that. Best place to fix will be the couchapp.

I kept `x-forwarded-for` in case that chain will be valuable.