### PR TITLE
add test for gzip hotfix

### DIFF
--- a/test/fixtures/get.json
+++ b/test/fixtures/get.json
@@ -40,6 +40,13 @@
                     "body": {}
                 }
             },
+            "core-util-is-gzipped": {
+                "response": {
+                    "status": 404,
+                    "headers": {},
+                    "body": {}
+                }
+            },
             "core-util-is/1.0.1": {
                 "response": {
                     "status": 404,
@@ -114,6 +121,17 @@
                         "content-type": "application/json"
                     },
                     "body": {}
+                }
+            },
+            "core-util-is-gzipped": {
+                "encoding": "base64",
+                "response": {
+                    "status": 200,
+                    "headers": {
+                        "content-type": "application/json",
+                        "content-encoding": "gzip"
+                    },
+                    "body": "H4sICNy9B1cAA3RlbXAAq1YqLk1OTi0uVrJSKCkqTa3lAgA9cyvvEgAAAA=="
                 }
             },
             "core-util-is/1.0.1": {


### PR DESCRIPTION
Backfilling a test for the [rc.14](https://github.com/krakenjs/kappa/releases/tag/v1.0.0-rc.14) release. I'd like to reevaluate this entire thing so that we can have proper encoding, determined by the request, on both sides of the proxy. Such a change would likely benefit from getting rid of the `Wreck.read` call and using a stream of gzip inflate -> json parse -> gzip deflate. But that's a discussion for another time and not super urgent—the json payloads are generally pretty tiny.
