### PR TITLE
update docker image version to rc.14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - couch_data:/usr/local/var/lib/couchdb
 
   kappa:
-    image: sisk/kappa:1.0.0-rc.11
+    image: sisk/kappa:1.0.0-rc.14
     depends_on:
       - registry
     ports:


### PR DESCRIPTION
Hey.

Master branch and rc14 tag still use rc.11 docker image.
Didn't work for me correctly when I git cloned and ran `docker-compose up`.
After changing it to the latest dockerhub version it became ok.

https://github.com/krakenjs/kappa/issues/119